### PR TITLE
Removed 1 unnecessary stubbing in PollForReleaseTaskTest.java

### DIFF
--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/PollForReleaseTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/PollForReleaseTaskTest.java
@@ -54,20 +54,6 @@ public class PollForReleaseTaskTest {
     }
 
     @Test
-    public void should_ReturnException_When_UploadIdIsMissing() {
-        // Given
-        final UploadRequest uploadRequest = baseRequest.newBuilder()
-            .build();
-
-        // When
-        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
-
-        // Then
-        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
-        assertThat(exception).hasMessageThat().contains("uploadId cannot be null");
-    }
-
-    @Test
     public void should_RetryPolling_When_StatusIsStartedOrFinished() throws Exception {
         // Given
         final UploadRequest uploadRequest = baseRequest.newBuilder()

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/SecondPollForReleaseTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/SecondPollForReleaseTaskTest.java
@@ -1,0 +1,66 @@
+package io.jenkins.plugins.appcenter.task.internal;
+
+import hudson.ProxyConfiguration;
+import hudson.model.TaskListener;
+import hudson.util.Secret;
+import io.jenkins.plugins.appcenter.AppCenterException;
+import io.jenkins.plugins.appcenter.api.AppCenterServiceFactory;
+import io.jenkins.plugins.appcenter.task.request.UploadRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import java.io.PrintStream;
+import java.util.concurrent.ExecutionException;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.BDDMockito.given;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class SecondPollForReleaseTaskTest {
+
+    @Rule
+    public MockitoRule experimentRule = MockitoJUnit.rule().strictness(Strictness.LENIENT);
+
+    @Rule
+    public MockWebServer mockWebServer = new MockWebServer();
+
+    @Mock
+    TaskListener mockTaskListener;
+
+    @Mock
+    PrintStream mockLogger;
+
+    @Mock
+    ProxyConfiguration mockProxyConfig;
+
+    private UploadRequest baseRequest;
+
+    private PollForReleaseTask task;
+
+    @Before
+    public void setUp() {
+        baseRequest = new UploadRequest.Builder().setOwnerName("owner-name").setAppName("app-name").build();
+        final AppCenterServiceFactory factory = new AppCenterServiceFactory(Secret.fromString("secret-token"), mockWebServer.url("/").toString(), mockProxyConfig);
+        task = new PollForReleaseTask(mockTaskListener, factory);
+    }
+
+    @Test
+    public void should_ReturnException_When_UploadIdIsMissing() {
+        // Given
+        final UploadRequest uploadRequest = baseRequest.newBuilder().build();
+        // When
+        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
+        // Then
+        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
+        assertThat(exception).hasMessageThat().contains("uploadId cannot be null");
+    }
+}


### PR DESCRIPTION
In our analysis of the project, we observed that:
1 unnecessary stubbing in `PollForReleaseTaskTest.setUp` is created but never executed by the test`PollForReleaseTaskTest.should_ReturnException_When_UploadIdIsMissing`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbing.