### PR TITLE
Removed 1 unnecessary stubbing in SetMetadataTaskTest.java

### DIFF
--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/SecondSetMetadataTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/SecondSetMetadataTaskTest.java
@@ -1,0 +1,92 @@
+package io.jenkins.plugins.appcenter.task.internal;
+
+import hudson.ProxyConfiguration;
+import hudson.model.TaskListener;
+import hudson.util.Secret;
+import io.jenkins.plugins.appcenter.AppCenterException;
+import io.jenkins.plugins.appcenter.api.AppCenterServiceFactory;
+import io.jenkins.plugins.appcenter.task.request.UploadRequest;
+import io.jenkins.plugins.appcenter.util.RemoteFileUtils;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import java.io.PrintStream;
+import java.util.concurrent.ExecutionException;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.BDDMockito.given;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class SecondSetMetadataTaskTest {
+
+    @Rule
+    public MockitoRule experimentRule = MockitoJUnit.rule().strictness(Strictness.LENIENT);
+
+    @Rule
+    public MockWebServer mockWebServer = new MockWebServer();
+
+    @Mock
+    TaskListener mockTaskListener;
+
+    @Mock
+    RemoteFileUtils remoteFileUtils;
+
+    @Mock
+    PrintStream mockLogger;
+
+    @Mock
+    ProxyConfiguration mockProxyConfig;
+
+    private UploadRequest baseRequest;
+
+    private SetMetadataTask task;
+
+    @Before
+    public void setUp() {
+        baseRequest = new UploadRequest.Builder().setOwnerName("owner-name").setAppName("app-name").setPathToApp("path-to-app").build();
+        final AppCenterServiceFactory factory = new AppCenterServiceFactory(Secret.fromString("secret-token"), mockWebServer.url("/").toString(), mockProxyConfig);
+        task = new SetMetadataTask(mockTaskListener, factory, remoteFileUtils);
+    }
+
+    @Test
+    public void should_ReturnException_When_UploadDomainIsMissing() {
+        // Given
+        final UploadRequest uploadRequest = baseRequest.newBuilder().build();
+        // When
+        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
+        // Then
+        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
+        assertThat(exception).hasMessageThat().contains("uploadDomain cannot be null");
+    }
+
+    @Test
+    public void should_ReturnException_When_PackageAssetIdIsMissing() {
+        // Given
+        final UploadRequest uploadRequest = baseRequest.newBuilder().setUploadDomain("upload-domain").build();
+        // When
+        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
+        // Then
+        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
+        assertThat(exception).hasMessageThat().contains("packageAssetId cannot be null");
+    }
+
+    @Test
+    public void should_ReturnException_When_TokenIsMissing() {
+        // Given
+        final UploadRequest uploadRequest = baseRequest.newBuilder().setUploadDomain("upload-domain").setPackageAssetId("package_asset_id").build();
+        // When
+        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
+        // Then
+        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
+        assertThat(exception).hasMessageThat().contains("token cannot be null");
+    }
+}

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/SetMetadataTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/SetMetadataTaskTest.java
@@ -59,51 +59,6 @@ public class SetMetadataTaskTest {
     }
 
     @Test
-    public void should_ReturnException_When_UploadDomainIsMissing() {
-        // Given
-        final UploadRequest uploadRequest = baseRequest.newBuilder()
-            .build();
-
-        // When
-        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
-
-        // Then
-        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
-        assertThat(exception).hasMessageThat().contains("uploadDomain cannot be null");
-    }
-
-    @Test
-    public void should_ReturnException_When_PackageAssetIdIsMissing() {
-        // Given
-        final UploadRequest uploadRequest = baseRequest.newBuilder()
-            .setUploadDomain("upload-domain")
-            .build();
-
-        // When
-        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
-
-        // Then
-        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
-        assertThat(exception).hasMessageThat().contains("packageAssetId cannot be null");
-    }
-
-    @Test
-    public void should_ReturnException_When_TokenIsMissing() {
-        // Given
-        final UploadRequest uploadRequest = baseRequest.newBuilder()
-            .setUploadDomain("upload-domain")
-            .setPackageAssetId("package_asset_id")
-            .build();
-
-        // When
-        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
-
-        // Then
-        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
-        assertThat(exception).hasMessageThat().contains("token cannot be null");
-    }
-
-    @Test
     public void should_ReturnResponse_When_RequestIsSuccessful() throws Exception {
         // Given
         final UploadRequest uploadRequest = baseRequest.newBuilder()


### PR DESCRIPTION
In our analysis of the project, we observed that:
1 unnecessary stubbing is created but never executed by 3 tests `SetMetadataTaskTest.should_ReturnException_When_UploadDomainIsMissing`, `SetMetadataTaskTest.should_ReturnException_When_PackageAssetIdIsMissing`,
`SetMetadataTaskTest.should_ReturnException_When_TokenIsMissing`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbing.