### PR TITLE
Removed 1 unnecessary stubbing in UpdateReleaseTaskTest.java

### DIFF
--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/SecondUpdateReleaseTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/SecondUpdateReleaseTaskTest.java
@@ -15,16 +15,20 @@ import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
-
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.BDDMockito.given;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
-public class UpdateReleaseTaskTest {
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class SecondUpdateReleaseTaskTest {
+
+    @Rule
+    public MockitoRule experimentRule = MockitoJUnit.rule().strictness(Strictness.LENIENT);
 
     @Rule
     public MockWebServer mockWebServer = new MockWebServer();
@@ -44,50 +48,19 @@ public class UpdateReleaseTaskTest {
 
     @Before
     public void setUp() {
-        baseRequest = new UploadRequest.Builder()
-            .setOwnerName("owner-name")
-            .setAppName("app-name")
-            .setPathToApp("path-to-app")
-            .build();
-        given(mockTaskListener.getLogger()).willReturn(mockLogger);
+        baseRequest = new UploadRequest.Builder().setOwnerName("owner-name").setAppName("app-name").setPathToApp("path-to-app").build();
         final AppCenterServiceFactory factory = new AppCenterServiceFactory(Secret.fromString("secret-token"), mockWebServer.url("/").toString(), mockProxyConfig);
         task = new UpdateReleaseTask(mockTaskListener, factory);
     }
-    
-    @Test
-    public void should_ReturnResponse_When_RequestIsSuccessful() throws Exception {
-        // Given
-        final UploadRequest uploadRequest = baseRequest.newBuilder()
-            .setUploadId("upload_id")
-            .build();
-        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("{" +
-            "\"id\": \"upload_id\",\n" +
-            "\"upload_status\": \"uploadFinished\"\n" +
-            "}")
-        );
-
-        // When
-        final UploadRequest actual = task.execute(uploadRequest).get();
-
-        // Then
-        assertThat(actual)
-            .isEqualTo(uploadRequest);
-    }
 
     @Test
-    public void should_ReturnException_When_RequestIsUnSuccessful() {
+    public void should_ReturnException_When_UploadIdIsMissing() {
         // Given
-        final UploadRequest uploadRequest = baseRequest.newBuilder()
-            .setUploadId("upload_id")
-            .build();
-        mockWebServer.enqueue(new MockResponse().setResponseCode(400));
-
+        final UploadRequest uploadRequest = baseRequest.newBuilder().build();
         // When
         final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
-
         // Then
-        final ExecutionException exception = assertThrows(ExecutionException.class, throwingRunnable);
-        assertThat(exception).hasCauseThat().isInstanceOf(AppCenterException.class);
-        assertThat(exception).hasCauseThat().hasMessageThat().contains("Updating release unsuccessful");
+        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
+        assertThat(exception).hasMessageThat().contains("uploadId cannot be null");
     }
 }


### PR DESCRIPTION
In our analysis of the project, we observed that:
1 unnecessary stubbing in `UpdateReleaseTaskTest.setUp` is created but never executed by the test`UpdateReleaseTaskTest.should_ReturnException_When_UploadIdIsMissing`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbing.